### PR TITLE
Restore missing dependencies file (soloader_defs.bzl)

### DIFF
--- a/tools/build_defs/oss/soloader_defs.bzl
+++ b/tools/build_defs/oss/soloader_defs.bzl
@@ -1,0 +1,83 @@
+def _deps_decorator(**kwargs):
+    """
+    Dependencies starting with '//deps/' should be provided (included in
+    'provided_deps' rather than 'deps'). This decorator takes care
+    of moving all such dependencies from 'deps' to 'provided_deps'.
+    """
+    all_deps = kwargs.get('deps', [])
+    oss_deps = [dep for dep in all_deps if dep.startswith('//deps:')]
+    kwargs['deps'] = [dep for dep in all_deps if dep not in oss_deps]
+    kwargs.setdefault('provided_deps', []).extend(oss_deps)
+    return kwargs
+
+def android_library(**kwargs):
+    native.android_library(**_deps_decorator(**kwargs))
+
+def android_aar(**kwargs):
+    native.android_aar(**_deps_decorator(**kwargs))
+
+def fb_java_library(**kwargs):
+    native.java_library(**_deps_decorator(**kwargs))
+
+def fb_core_android_library(**kwargs):
+    android_library(**kwargs)
+
+DEPENDENCIES_INDEX = {}
+
+def _add_dependency_to_index(name, **dep):
+    DEPENDENCIES_INDEX[name] = dep
+
+def maven_library(
+        name,
+        group,
+        artifact,
+        version,
+        sha1,
+        visibility,
+        packaging='jar',
+        scope='compiled'):
+    """
+    Creates remote_file and prebuilt_jar rules for a maven artifact.
+    """
+    _add_dependency_to_index(
+        name=name,
+        group=group,
+        artifact=artifact,
+        version=version,
+        sha1=sha1,
+        packaging=packaging,
+        scope=scope
+    )
+
+    remote_file_name = '{}-remote'.format(name)
+    native.remote_file(
+        name=remote_file_name,
+        out='{}-{}.{}'.format(name, version, packaging),
+        url=':'.join(['mvn', group, artifact, packaging, version]),
+        sha1=sha1
+    )
+
+    if packaging == 'jar':
+        native.prebuilt_jar(
+            name=name,
+            binary_jar=':{}'.format(remote_file_name),
+            visibility=visibility
+        )
+    else:
+        native.android_prebuilt_aar(
+            name=name,
+            aar=':{}'.format(remote_file_name),
+            visibility=visibility
+        )
+
+def define_list_deps_target():
+    """
+    Generates rule that dumps all maven_libraries defined in given
+    BUCK file in json format.
+    """
+    json_deps = struct(**DEPENDENCIES_INDEX).to_json()
+    native.genrule(
+        name='list-deps',
+        out='dependencies.json',
+        cmd="""echo '{}' > $OUT""".format(json_deps)
+    )


### PR DESCRIPTION
I found that the build was broken:

```
$ buck fetch //...
Not using buckd because watchman isn't installed.
Buck wasn't able to parse /Users/eoconnell/workspace/SoLoader/BUCK:
IOError: [Errno 2] No such file or directory: '/Users/eoconnell/workspace/SoLoader/tools/build_defs/oss/soloader_defs.bzl'
Call stack:
  File "/Users/eoconnell/workspace/SoLoader/BUCK", line 1
    load("//tools/build_defs/oss:soloader_defs.bzl", "android_aar")
```

I noticed that the only `.bzl` file was removed [in this commit](https://github.com/facebook/SoLoader/commit/1c3cb5e1ee0b896cd9f83868b23bea1504b4cd25), so I simply restored it and put it where the config wanted it. Seems to be happier now!