### PR TITLE
Add support for app bundle

### DIFF
--- a/java/com/facebook/soloader/ApkSoSource.java
+++ b/java/com/facebook/soloader/ApkSoSource.java
@@ -46,11 +46,11 @@ public class ApkSoSource extends ExtractFromZipSoSource {
 
   private final int mFlags;
 
-  public ApkSoSource(Context context, String name, int flags) {
+  public ApkSoSource(Context context, String apkPath, String name, int flags) {
     super(
         context,
         name,
-        new File(context.getApplicationInfo().sourceDir),
+        new File(apkPath),
         // The regular expression matches libraries that would ordinarily be unpacked
         // during installation.
         "^lib/([^/]+)/([^/]+\\.so)$");

--- a/java/com/facebook/soloader/SoLoader.java
+++ b/java/com/facebook/soloader/SoLoader.java
@@ -270,13 +270,16 @@ public class SoLoader {
               ArrayList<UnpackingSoSource> backupSources = new ArrayList<>();
               ApkSoSource mainApkSource = new ApkSoSource(context, mainApkDir, SO_STORE_NAME_MAIN, apkSoSourceFlags);
               backupSources.add(mainApkSource);
-              Log.d(TAG, "adding backup  source: " + mainApkSource.toString());
+              Log.d(TAG, "adding backup source from : " + mainApkSource.toString());
 
-              int splitIndex = 0;
-              for (String splitApkDir: context.getApplicationInfo().splitSourceDirs) {
-                ApkSoSource splittedApkSource = new ApkSoSource(context, splitApkDir, SO_STORE_NAME_SPLITTED + (splitIndex++), apkSoSourceFlags);
-                Log.d(TAG, "adding backup  source: " + mainApkSource.toString());
-                backupSources.add(splittedApkSource);
+              if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                Log.d(TAG, "adding backup sources from split apks");
+                int splitIndex = 0;
+                for (String splitApkDir : context.getApplicationInfo().splitSourceDirs) {
+                  ApkSoSource splittedApkSource = new ApkSoSource(context, splitApkDir, SO_STORE_NAME_SPLITTED + (splitIndex++), apkSoSourceFlags);
+                  Log.d(TAG, "adding backup source: " + splittedApkSource.toString());
+                  backupSources.add(splittedApkSource);
+                }
               }
 
               sBackupSoSources = backupSources.toArray(new UnpackingSoSource[backupSources.size()]);

--- a/java/com/facebook/soloader/SoLoader.java
+++ b/java/com/facebook/soloader/SoLoader.java
@@ -272,7 +272,7 @@ public class SoLoader {
               backupSources.add(mainApkSource);
               Log.d(TAG, "adding backup source from : " + mainApkSource.toString());
 
-              if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+              if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && context.getApplicationInfo().splitSourceDirs != null) {
                 Log.d(TAG, "adding backup sources from split apks");
                 int splitIndex = 0;
                 for (String splitApkDir : context.getApplicationInfo().splitSourceDirs) {


### PR DESCRIPTION
PR is related to #19

**Problem**
SoLoader cannot load `.so`libraries when an application is installed through [App Bundle](https://developer.android.com/platform/technology/app-bundle/) with config: 
```
bundle {
    abi {
        enableSplit = true
    }
}
```

The reason is that app bundle installation consists of multiple apks. For instance: 
- `base.apk`
- `split_config.arm64_v8a.apk`
- `split_config.xxxhdpi.apk`

`SoLoader` class creates `ApkSoSource` pointing only to  `base.apk`. But `*.so` files exist only in `split_config.arm64_v8a.apk`

**Solution** 
Create separate `ApkSoSource` for each apk in the application folder. I couldn't figure out how to filter out apk without lib folder.

**Testing**
I haven't tried this with dynamic feature modules yet. So I can't say that it fully fixes #19. But at least it fixes facebook/fresco#2253
Any help with dynamic modules testing would be much appreciated.

**P.S.**
Due to some reasons, I can't wait for the new release of SoLoader lib, so I have published a temporary patched version to bintray in [my account](https://bintray.com/nnesterov/maven/patched-soloader)
with different grouipId `com.avito.android:patched-soloader:0.1.0`
If you are against publishing your lib in a different account, please let me know. I'll remove my version immediately. 
