### PR TITLE
Optimize extraction strategy

### DIFF
--- a/java/com/facebook/soloader/MinElf.java
+++ b/java/com/facebook/soloader/MinElf.java
@@ -31,6 +31,26 @@ import java.nio.channels.FileChannel;
  */
 public final class MinElf {
 
+  public static enum ISA {
+    NOT_SO("not_so"),
+    X86("x86"),
+    ARM("armeabi-v7a"),
+    X86_64("x86_64"),
+    AARCH64("arm64-v8a"),
+    OTHERS("others");
+
+    private final String value;
+
+    ISA(final String value) {
+      this.value = value;
+    }
+
+    @Override
+    public String toString() {
+      return value;
+    }
+  };
+
   public static final int ELF_MAGIC = 0x464c457f;
 
   public static final int DT_NULL = 0;

--- a/java/com/facebook/soloader/SysUtil.java
+++ b/java/com/facebook/soloader/SysUtil.java
@@ -30,6 +30,9 @@ import java.io.FileDescriptor;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.RandomAccessFile;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
 
 public final class SysUtil {
 
@@ -121,7 +124,36 @@ public final class SysUtil {
   private static final class LollipopSysdeps {
     @DoNotOptimize
     public static String[] getSupportedAbis() {
-      return Build.SUPPORTED_ABIS;
+      String[] supportedAbis = Build.SUPPORTED_ABIS;
+      ArrayList<String> priorAbis = new ArrayList<>();
+      try {
+        // SoLoader will give first rank to arm64-v8a & x86_64, if current process is app_process64.
+        // Otherwise(means current process is app_process32), give first rank to armeabi-v7a & x86.
+        if (Os.readlink("/proc/self/exe").contains("64")) {
+          priorAbis.add(MinElf.ISA.AARCH64.toString());
+          priorAbis.add(MinElf.ISA.X86_64.toString());
+        } else {
+          priorAbis.add(MinElf.ISA.ARM.toString());
+          priorAbis.add(MinElf.ISA.X86.toString());
+        }
+      } catch(ErrnoException e) {
+        throw new RuntimeException(e);
+      }
+      final ArrayList<String> finalPriorAbis = priorAbis;
+      // Reorder supported ABIs based on preferred ABIs for the current process.
+      Arrays.sort(supportedAbis, new Comparator<String>() {
+        @Override
+        public int compare(String o1, String o2) {
+          if (finalPriorAbis.contains(o1)) {
+            return -1;
+          } else if (finalPriorAbis.contains(o2)) {
+            return 1;
+          } else {
+            return 0;
+          }
+        }
+      });
+      return supportedAbis;
     }
 
     @DoNotOptimize


### PR DESCRIPTION
fix [bug](https://github.com/facebook/react-native/issues/25490).

Make extraction strategy of .so files smarter.
In past versions, SoLoader follows standard rule to extract .so files from zip. However, some phones customize application installer which doesn't follow standard rule. And then, may cause crash because .so files of different ABI is loaded in the application.
In this version, SoLoader will parse .so files in lib dir to determine which ABI of .so files should be extracted to lib-main dir. It can ensure that only one type of ABI will be loaded in the application so that SoLoader can be adapted for more models.