### PR TITLE
Make SoLoader.init public so consumers can provide their own loaders

### DIFF
--- a/java/com/facebook/soloader/SoLoader.java
+++ b/java/com/facebook/soloader/SoLoader.java
@@ -184,7 +184,7 @@ public class SoLoader {
    * @param flags Zero or more of the SOLOADER_* flags
    * @param soFileLoader
    */
-  private static void init(Context context, int flags, @Nullable SoFileLoader soFileLoader)
+  public static void init(Context context, int flags, @Nullable SoFileLoader soFileLoader)
       throws IOException {
     StrictMode.ThreadPolicy oldPolicy = StrictMode.allowThreadDiskWrites();
     try {
@@ -340,6 +340,10 @@ public class SoLoader {
   }
 
   private static synchronized void initSoLoader(@Nullable SoFileLoader soFileLoader) {
+    if (sSoFileLoader != null) {
+      return;
+    }
+
     if (soFileLoader != null) {
       sSoFileLoader = soFileLoader;
       return;

--- a/java/com/facebook/soloader/SoLoader.java
+++ b/java/com/facebook/soloader/SoLoader.java
@@ -340,10 +340,6 @@ public class SoLoader {
   }
 
   private static synchronized void initSoLoader(@Nullable SoFileLoader soFileLoader) {
-    if (sSoFileLoader != null) {
-      return;
-    }
-
     if (soFileLoader != null) {
       sSoFileLoader = soFileLoader;
       return;


### PR DESCRIPTION
`ReactInstanceManager.initializeSoLoaderIfNecessary()` may be called twice if `ReactInstanceManagerBuilder` is used to create a `ReactInstanceManager`, unnecessarily re-initializing default `SoFileLoader` and potentially overwriting a custom one.

This also makes `SoLoader.init(Context, int, SoFileLoader)` public so consumers can provide their own loaders.