### PR TITLE
Fix annotations artifact

### DIFF
--- a/.buckconfig
+++ b/.buckconfig
@@ -1,12 +1,6 @@
 [alias]
 [java]
     src_roots = /java/
-[project]
-    # IntelliJ requires that every Android module have an
-    # AndroidManifest.xml file associated with it. In practice,
-    # most of this is unnecessary boilerplate, so we create one
-    # "shared" AndroidManifest.xml file that can be used as a default.
-    default_android_manifest = //res/AndroidManifest.xml
 [android]
     target = android-26
     build_tools_version = 27.0.3

--- a/BUCK
+++ b/BUCK
@@ -14,7 +14,7 @@ export_file(
     out = "nativeloader.jar",
 )
 
-fb_java_library(
+java_library(
     name = "annotation",
     deps = [
         "//java/com/facebook/soloader:annotation",

--- a/BUCK
+++ b/BUCK
@@ -14,9 +14,8 @@ export_file(
     out = "nativeloader.jar",
 )
 
-android_aar(
+fb_java_library(
     name = "annotation",
-    manifest_skeleton = "AndroidManifestSkeleton.xml",
     deps = [
         "//java/com/facebook/soloader:annotation",
     ],


### PR DESCRIPTION
These appear to be intended to be a plain java library but were still defined as an aar, which then had a conflicting manifest package name as well.

Resolves #58 