### PR TITLE
Fix travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 os: linux
+arch: amd64
+dist: trusty
 sudo: true
 language: android
 android:
@@ -6,8 +8,13 @@ android:
     - build-tools-27.0.3
     - android-26
 
+before_install:
+  - sudo apt-get -y install ant
+  - sudo apt-get -y install python3-pip
+  - sudo pip3 install typing-extensions
+
 before_script:
-  - sudo apt-get install ant
+  - sudo update-alternatives --install /usr/bin/python python /usr/bin/python3 10
   - git clone https://github.com/facebook/buck.git --branch master --depth=1 $HOME/buck
   - cd $HOME/buck && ant
   - $HOME/buck/bin/buck --version


### PR DESCRIPTION
Default android build host only pre-installed python3.4 that doesn't
have built-in typing.
Use pip to install the typing-extensions and force to use python3 to run
the python scripts.

TEST PLAN:
https://travis-ci.com/github/simpleton/SoLoader/builds/188969198