### PR TITLE
Add synchronized block to protect against race condition

### DIFF
--- a/java/com/facebook/soloader/SoLoader.java
+++ b/java/com/facebook/soloader/SoLoader.java
@@ -205,11 +205,7 @@ public class SoLoader {
       isSystemApp = checkIfSystemApp(context, flags);
       initSoLoader(soFileLoader);
       initSoSources(context, flags, soFileLoader);
-      synchronized(NativeLoader.class) {
-        if (!NativeLoader.isInitialized()) {
-          NativeLoader.init(new NativeLoaderToSoLoaderDelegate());
-        }
-      }
+      NativeLoader.initIfUninitialized(new NativeLoaderToSoLoaderDelegate());
     } finally {
       StrictMode.setThreadPolicy(oldPolicy);
     }

--- a/java/com/facebook/soloader/SoLoader.java
+++ b/java/com/facebook/soloader/SoLoader.java
@@ -205,8 +205,10 @@ public class SoLoader {
       isSystemApp = checkIfSystemApp(context, flags);
       initSoLoader(soFileLoader);
       initSoSources(context, flags, soFileLoader);
-      if (!NativeLoader.isInitialized()) {
-        NativeLoader.init(new NativeLoaderToSoLoaderDelegate());
+      synchronized(NativeLoader.class) {
+        if (!NativeLoader.isInitialized()) {
+          NativeLoader.init(new NativeLoaderToSoLoaderDelegate());
+        }
       }
     } finally {
       StrictMode.setThreadPolicy(oldPolicy);

--- a/java/com/facebook/soloader/nativeloader/NativeLoader.java
+++ b/java/com/facebook/soloader/nativeloader/NativeLoader.java
@@ -112,4 +112,16 @@ public class NativeLoader {
   public static synchronized boolean isInitialized() {
     return sDelegate != null;
   }
+
+  /**
+   * Perform an initialization only if {@code NativeLoader} has not already been initialized.
+   * This protects against race conditions where isInitialized and init are called by multiple
+   * threads and both threads end up trying to perform an initialization
+   */
+
+  public static synchronized void initIfUninitialized(NativeLoaderDelegate delegate) {
+    if(!isInitialized()) {
+      init(delegate);
+    }
+  }
 }


### PR DESCRIPTION
Fixes: #60

As mentioned in issue #60 if the init method is called twice from two different threads it can result in a race condition where both threads receive false for `NativeLoader.isInitialized()`, but, when `NativeLoader.init()` is run for a second time it throws an exception.

Adding a synchronized block here ensures that only one thread will be able to query the initialisation state and trigger the initialisation at a time.