### PR TITLE
Migrate google java format from 1.7 -> 1.19.2

### DIFF
--- a/java/com/facebook/soloader/NativeDeps.java
+++ b/java/com/facebook/soloader/NativeDeps.java
@@ -152,7 +152,8 @@ public final class NativeDeps {
               sWaitForDepsFileLock.writeLock().unlock();
               sUseDepsFileAsync = false;
             }
-          };
+          }
+          ;
         };
 
     new Thread(runnable, "soloader-nativedeps-init").start();
@@ -183,7 +184,8 @@ public final class NativeDeps {
     if (!success) {
       LogUtil.w(
           LOG_TAG,
-          "Failed to extract native deps from APK, falling back to using MinElf to get library dependencies.");
+          "Failed to extract native deps from APK, falling back to using MinElf to get library"
+              + " dependencies.");
     }
 
     return success;

--- a/java/com/facebook/soloader/SoSource.java
+++ b/java/com/facebook/soloader/SoSource.java
@@ -146,7 +146,9 @@ public abstract class SoSource {
     return SysUtil.getSupportedAbis();
   }
 
-  /** @return the name of this SoSource for logging purposes */
+  /**
+   * @return the name of this SoSource for logging purposes
+   */
   public abstract String getName();
 
   /**

--- a/java/com/facebook/soloader/SysUtil.java
+++ b/java/com/facebook/soloader/SysUtil.java
@@ -179,7 +179,8 @@ public final class SysUtil {
         LogUtil.e(
             TAG,
             String.format(
-                "Could not read /proc/self/exe. Falling back to default ABI list: %s. errno: %d Err msg: %s",
+                "Could not read /proc/self/exe. Falling back to default ABI list: %s. errno: %d Err"
+                    + " msg: %s",
                 Arrays.toString(supportedAbis), e.errno, e.getMessage()));
         return Build.SUPPORTED_ABIS;
       }

--- a/java/com/facebook/soloader/SystemLoadLibraryWrapper.java
+++ b/java/com/facebook/soloader/SystemLoadLibraryWrapper.java
@@ -16,7 +16,9 @@
 
 package com.facebook.soloader;
 
-/** @see SoLoader#setSystemLoadLibraryWrapper */
+/**
+ * @see SoLoader#setSystemLoadLibraryWrapper
+ */
 public interface SystemLoadLibraryWrapper {
   void loadLibrary(String libName);
 }


### PR DESCRIPTION
Summary:
This diff migrates google java format form 1.7 to 1.19.2. This update will allow for new language features from java 17 and 21. This diff also formats all necessary files.

 Changelog:
    [Internal][Changed] - Updated format from google-java-format 1.7 -> 1.19.2

Reviewed By: IanChilds

Differential Revision: D52786052


