### PR TITLE
Allow OSS libraries to provide an ExternalSoMapping during init.

### DIFF
--- a/java/com/facebook/soloader/ExternalSoMapping.java
+++ b/java/com/facebook/soloader/ExternalSoMapping.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.soloader;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
+
+/**
+ * Similar to {@link MergedSoMapping}, but this interface allows extrenal libraries and map to
+ * provide their own mapping from Open Source.
+ */
+@ThreadSafe
+interface ExternalSoMapping {
+  @Nullable
+  String mapLibName(String preMergedLibName);
+
+  void invokeJniOnload(String preMergedLibName);
+}


### PR DESCRIPTION
Summary:
As of now, MergedSoMapping was stabbed to a static empty class, so it was not
possible for libraries or apps in OSS to provide an implementation for it.

I'm extending the SoLoader API to offer a `init` method which accepts a
new interface called `ExternalSoMapping` which is not static, and libraries can
implement.

Differential Revision: D60110088
