### PR TITLE
Update Elf64.java

### DIFF
--- a/java/com/facebook/soloader/Elf64.java
+++ b/java/com/facebook/soloader/Elf64.java
@@ -12,56 +12,77 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ * Este arquivo define constantes para manipulação de arquivos ELF64.
+ * As classes internas representam as diferentes seções e cabeçalhos do formato ELF.
+ * Todas as constantes são offsets baseados na especificação do ELF64.
  */
 
 package com.facebook.soloader;
 
-// Java structures that contain the offsets of fields in various ELF64 ABI structures.
-// com.facebook.soloader.MinElf uses these structures while parsing ELF64 files.
+// Estruturas ELF64 contendo offsets para interpretação do formato ELF64.
 final class Elf64 {
-  static class Dyn { // Dynamic section
-    public static final int D_TAG = 0x0; // Tag, controls the interpretation of d_un
-    public static final int D_UN = 0x8; // Union that contains the actual value of the dynamic entry
-  }
 
-  static class Ehdr { // ELF header
-    public static final int E_IDENT = 0x0; // ELF identification bytes
-    public static final int E_TYPE = 0x10; // Object file type
-    public static final int E_MACHINE = 0x12; // Architecture type
-    public static final int E_VERSION = 0x14; // Object file version
-    public static final int E_ENTRY = 0x18; // Entry point address
-    public static final int E_PHOFF = 0x20; // Program header offset
-    public static final int E_SHOFF = 0x28; // Section header offset
-    public static final int E_FLAGS = 0x30; // Processor-specific flags
-    public static final int E_EHSIZE = 0x34; // ELF header size
-    public static final int E_PHENTSIZE = 0x36; // Size of program header entry
-    public static final int E_PHNUM = 0x38; // Number of program header entries
-    public static final int E_SHENTSIZE = 0x3a; // Size of section header entry
-    public static final int E_SHNUM = 0x3c; // Number of section header entries
-    public static final int E_SHSTRNDX = 0x3e; // Section name string table index
-  }
+    // Constantes auxiliares para tamanhos de offsets
+    private static final int OFFSET_SIZE_32BITS = 0x4;
+    private static final int OFFSET_SIZE_64BITS = 0x8;
 
-  static class Phdr { // Program Header
-    public static final int P_TYPE = 0x0; // Segment type
-    public static final int P_FLAGS = 0x4; // Segment flags
-    public static final int P_OFFSET = 0x8; // Segment file offset
-    public static final int P_VADDR = 0x10; // Segment virtual address
-    public static final int P_PADDR = 0x18; // Segment physical address
-    public static final int P_FILESZ = 0x20; // Segment size in file
-    public static final int P_MEMSZ = 0x28; // Segment size in memory
-    public static final int P_ALIGN = 0x30; // Segment alignment
-  }
+    // Classe representando a seção dinâmica
+    static class Dyn {
+        public static final int D_TAG = 0x0; // Tipo de tag (interpretação do d_un)
+        public static final int D_UN = OFFSET_SIZE_64BITS; // Valor dinâmico
+    }
 
-  static class Shdr { // Section Header
-    public static final int SH_NAME = 0x0; // Section name (string table index)
-    public static final int SH_TYPE = 0x4; // Section type
-    public static final int SH_FLAGS = 0x8; // Section flags
-    public static final int SH_ADDR = 0x10; // Section virtual address
-    public static final int SH_OFFSET = 0x18; // Section file offset
-    public static final int SH_SIZE = 0x20; // Section size in bytes
-    public static final int SH_LINK = 0x28; // Section header table index link
-    public static final int SH_INFO = 0x2c; // Section extra information
-    public static final int SH_ADDRALIGN = 0x30; // Section address alignment
-    public static final int SH_ENTSIZE = 0x38; // Section entry size
-  }
+    // Classe representando o cabeçalho ELF
+    static class Ehdr {
+        public static final int E_IDENT = 0x0; // Identificador ELF
+        public static final int E_TYPE = 0x10; // Tipo do arquivo
+        public static final int E_MACHINE = E_TYPE + OFFSET_SIZE_32BITS; // Tipo de arquitetura
+        public static final int E_VERSION = 0x14; // Versão do arquivo
+        public static final int E_ENTRY = 0x18; // Endereço de entrada
+        public static final int E_PHOFF = 0x20; // Offset para cabeçalhos de programas
+        public static final int E_SHOFF = 0x28; // Offset para cabeçalhos de seções
+        public static final int E_FLAGS = 0x30; // Flags específicas do processador
+        public static final int E_EHSIZE = 0x34; // Tamanho do cabeçalho ELF
+        public static final int E_PHENTSIZE = 0x36; // Tamanho das entradas de programa
+        public static final int E_PHNUM = 0x38; // Número de entradas no cabeçalho do programa
+        public static final int E_SHENTSIZE = 0x3a; // Tamanho das entradas de seções
+        public static final int E_SHNUM = 0x3c; // Número de entradas no cabeçalho de seções
+        public static final int E_SHSTRNDX = 0x3e; // Índice da tabela de strings
+    }
+
+    // Classe representando o cabeçalho do programa
+    static class Phdr {
+        public static final int P_TYPE = 0x0; // Tipo do segmento
+        public static final int P_FLAGS = OFFSET_SIZE_32BITS; // Flags do segmento
+        public static final int P_OFFSET = OFFSET_SIZE_64BITS; // Offset no arquivo
+        public static final int P_VADDR = 0x10; // Endereço virtual
+        public static final int P_PADDR = 0x18; // Endereço físico
+        public static final int P_FILESZ = 0x20; // Tamanho no arquivo
+        public static final int P_MEMSZ = 0x28; // Tamanho na memória
+        public static final int P_ALIGN = 0x30; // Alinhamento do segmento
+    }
+
+    // Classe representando o cabeçalho da seção
+    static class Shdr {
+        public static final int SH_NAME = 0x0; // Nome da seção (índice na tabela de strings)
+        public static final int SH_TYPE = OFFSET_SIZE_32BITS; // Tipo da seção
+        public static final int SH_FLAGS = OFFSET_SIZE_64BITS; // Flags da seção
+        public static final int SH_ADDR = 0x10; // Endereço virtual
+        public static final int SH_OFFSET = 0x18; // Offset no arquivo
+        public static final int SH_SIZE = 0x20; // Tamanho em bytes
+        public static final int SH_LINK = 0x28; // Índice de ligação
+        public static final int SH_INFO = 0x2c; // Informações adicionais
+        public static final int SH_ADDRALIGN = 0x30; // Alinhamento do endereço
+        public static final int SH_ENTSIZE = 0x38; // Tamanho das entradas
+    }
+
+    /**
+     * Valida se o identificador ELF está correto.
+     * @param eIdent O array de bytes contendo o identificador ELF.
+     * @return true se o identificador for válido, false caso contrário.
+     */
+    public static boolean isValidElf64(byte[] eIdent) {
+        return eIdent.length >= 4 && eIdent[0] == 0x7F && eIdent[1] == 'E' && eIdent[2] == 'L' && eIdent[3] == 'F';
+    }
 }


### PR DESCRIPTION
Constantes auxiliares: adicionei OFFSET_SIZE_32BITS e OFFSET_SIZE_64BITS para evitar números mágicos e facilitar alterações futuras; Com os comentários melhorados, a documentação mais clara sobre o propósito de cada constante e classe; o método utilitário, adiciona isValidElf64 para verificar identificadores ELF de forma reutilizável e a manutenção de design tem todas as classes e constantes permanecendo no mesmo arquivo para seguir a estrutura original