### PR TITLE
Do not throw IOException for init(Context,ExternalSoMapping)

### DIFF
--- a/java/com/facebook/soloader/SoLoader.java
+++ b/java/com/facebook/soloader/SoLoader.java
@@ -328,14 +328,16 @@ public class SoLoader {
    *
    * @param context application context
    * @param externalSoMapping the custom {@link ExternalSoMapping} if the App is using SoMerging.
-   * @throws IOException IOException
    */
-  public static void init(Context context, @Nullable ExternalSoMapping externalSoMapping)
-      throws IOException {
+  public static void init(Context context, @Nullable ExternalSoMapping externalSoMapping) {
     synchronized (SoLoader.class) {
       SoLoader.externalSoMapping = externalSoMapping;
     }
-    init(context, 0);
+    try {
+      init(context, 0);
+    } catch (IOException ex) {
+      throw new RuntimeException(ex);
+    }
   }
 
   /**


### PR DESCRIPTION
Summary:
This mimics the same behavior of `init(Context, boolean)` and lifts the requirement for
Java consumers to catch an exception explicitely.

See https://github.com/facebook/react-native-website/pull/4397

Differential Revision: D67032849


